### PR TITLE
Fix version

### DIFF
--- a/lib/artii/base.rb
+++ b/lib/artii/base.rb
@@ -71,7 +71,11 @@ module Artii
     end
 
     def version
-      Gem::Specification::load('artii.gemspec').version.to_s
+      file = 'artii.gemspec'
+      unless File.exists? file
+        file = `gem which artii`.sub("/lib/artii.rb\n", "/#{file}")
+      end
+      Gem::Specification::load(file).version.to_s
     end
   end
 end


### PR DESCRIPTION
The ```-v``` call looks up the gemspec to get the version, but it assumes that the gemspec is in the current directory.  True for development, not true for anytime else.

I changed the call to use ```gem``` to look up the location of the gemspec, when the gemspec can't be found locally.  This should resolve #4. 

I usually avoid dialing out like this, and I prefer the Bundler method of putting the version in the gem itself.  However, this is the simplest fix I could think of for this problem.